### PR TITLE
fixed bug when using different store_dir then 'CA'

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'opentable/sslcertificate'
-version '2.0.0'
+version '2.0.299'
 author 'opentable'
 license 'MIT'
 summary 'Puppet module to manage SSL Certificates on WIndows Server 2008 and upwards'

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -22,7 +22,7 @@ switch -regex ($cert.Extension.ToUpper()) {
 $store = new-object System.Security.Cryptography.X509Certificates.X509Store("<%= @store_dir %>","<%= @root_store %>")
 $store.open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
 
-$intermediatestore = new-object System.Security.Cryptography.X509Certificates.X509Store("CA","<%= @root_store %>")
+$intermediatestore = new-object System.Security.Cryptography.X509Certificates.X509Store("<%= @store_dir %>","<%= @root_store %>")
 $intermediatestore.open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
 
 foreach($cert in $pfx) {

--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -20,7 +20,7 @@ switch -regex ($certificate.Extension.ToUpper()) {
 
 
 $installedCerts = @(Get-ChildItem -R cert:\<%= @root_store %>\<%= @store_dir %>)
-$intermediateCerts = @(Get-ChildItem -R cert:\<%= @root_store %>\CA)
+$intermediateCerts = @(Get-ChildItem -R cert:\<%= @root_store %>\<%= @store_dir %>)
 
 $installedCertCount = 0
 $installedIntermediateCount = 0


### PR DESCRIPTION
Hi,

I am using your puppet module, i thing its best way how to use windows certificates in puppet. I found that you are using hardcoded store_dir 'CA' which doesn't reflect used settings.

Have a nice day :-)